### PR TITLE
Add support for in-process applet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ install-sh
 missing
 stamp-h1
 xmonad-log-applet
+.libs/
+compile
+libtool
+libxmonad-log-applet.la
+libxmonad_log_applet_la-main.lo
+ltmain.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,39 @@
 plugindir = $(PLUGIN_DIR)
+
+if PANEL_GNOME_IN_PROC
+
+xmonad_log_appletdir = $(libdir)/gnome-panel/modules
+PLUGIN_DIR_ = $(libdir)/gnome-panel/modules
+xmonad_log_applet_LTLIBRARIES = libxmonad-log-applet.la
+PLUGIN_FILE = libxmonad-log-applet.la
+IN_PROC_STR = "InProcess=true"
+
+libxmonad_log_applet_la_SOURCES = main.c
+libxmonad_log_applet_la_CPPFLAGS = \
+	$(GLIB_CFLAGS) \
+	$(DBUS_GLIB_CFLAGS) \
+	$(LIBPANEL_CFLAGS) \
+	$(XCB_CFLAGS)
+
+libxmonad_log_applet_la_LIBADD = \
+	$(GLIB_LIBS) \
+	$(DBUS_GLIB_LIBS) \
+	$(LIBPANEL_LIBS) \
+	$(XCB_LIBS)
+
+libxmonad_log_applet_la_LDFLAGS = \
+	-module -avoid-version \
+	$(WARN_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(XCB_LDFLAGS)
+
+else
+
 plugin_PROGRAMS = xmonad-log-applet
+PLUGIN_DIR_ = $(PLUGIN_DIR)
+PLUGIN_FILE = xmonad-log-applet
 
 xmonad_log_applet_SOURCES = main.c
-
 xmonad_log_applet_CPPFLAGS = \
 	$(GLIB_CFLAGS) \
 	$(DBUS_GLIB_CFLAGS) \
@@ -15,21 +46,29 @@ xmonad_log_applet_LDADD = \
 	$(LIBPANEL_LIBS) \
 	$(XCB_LIBS)
 
+endif
+
 appletdir = $(LIBPANEL_APPLET_DIR)
 if PANEL_GNOME
 applet_files = org.gnome.panel.XmonadLogApplet.panel-applet
 $(applet_files): $(applet_files:.panel-applet=.panel-applet.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR_)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 if PANEL_MATE
 applet_files = org.mate.panel.XmonadLogApplet.mate-panel-applet
 $(applet_files): $(applet_files:.mate-panel-applet=.mate-panel-applet.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR_)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 if PANEL_XFCE4
 applet_files = xmonad-log-applet.desktop
 $(applet_files): $(applet_files:.desktop=.desktop.in)
-	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" $< > $@
+	$(SED) -e "s|\@PLUGIN_DIR\@|$(PLUGIN_DIR)|" \
+		   -e "s|\@PLUGIN_FILE\@|$(PLUGIN_FILE)|" \
+		   -e "s|\@IN_PROC\@|$(IN_PROC_STR)|" $< > $@
 endif
 
 applet_DATA = $(applet_files)

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,10 @@ AM_INIT_AUTOMAKE([foreign])
 
 AM_MAINTAINER_MODE
 
+LT_PREREQ([2.2.6])
+LT_INIT([dlopen disable-static])
+LT_LIB_M
+
 AC_PROG_CC
 AC_PROG_SED
 AC_PROG_INSTALL
@@ -61,6 +65,7 @@ AS_IF(
         ,
     [AC_MSG_ERROR([Unknown panel type, use gnome2, gnome3, gnomeflashback, mate or xfce4])]
 )
+PKG_CHECK_MODULES(LIBPANEL_GE_3_22, libpanel-applet >= 3.22.0, PANEL_GNOME_IN_PROC=1, PANEL_GNOME_IN_PROC=0)
 AC_SUBST([LIBPANEL_APPLET_DIR])
 AC_SUBST([PLUGIN_DIR])
 
@@ -70,6 +75,8 @@ AM_CONDITIONAL([PANEL_GNOME3], [test "x$panel" = xgnome3])
 AM_CONDITIONAL([PANEL_GNOMEFLASHBACK], [test "x$panel" = xgnomeflashback])
 AM_CONDITIONAL([PANEL_MATE], [test "x$panel" = xmate])
 AM_CONDITIONAL([PANEL_XFCE4], [test "x$panel" = xxfce4])
+AM_CONDITIONAL([PANEL_GNOME_IN_PROC], [test "$PANEL_GNOME_IN_PROC" -eq 1])
+AS_IF([test "$PANEL_GNOME_IN_PROC" -eq 1], [AC_DEFINE([PANEL_GNOME_IN_PROC], [1], [Define if using libpanel-applet >= 3.22.0 and we need in process applet.])])
 
 AC_CONFIG_FILES([Makefile])
 

--- a/main.c
+++ b/main.c
@@ -210,7 +210,11 @@ static void set_up_dbus_transfer(GtkWidget *buf)
     if(connection == NULL) {
         g_printerr("Failed to open connection: %s\n", error->message);
         g_error_free(error);
-        exit(1);
+        #ifdef PANEL_GNOME_IN_PROC
+        return;
+        #else
+        exit(-1);
+        #endif
     }
 
     proxy = dbus_g_proxy_new_for_name(
@@ -240,7 +244,9 @@ static void xmonad_log_applet_fill(GtkContainer *container)
         PANEL_APPLET_EXPAND_MINOR |
         PANEL_APPLET_HAS_HANDLE);
 
+    #ifndef PANEL_GNOME_IN_PROC
     panel_applet_set_background_widget(applet, GTK_WIDGET(applet));
+    #endif
 #endif
 #ifdef PANEL_MATE
     mate_panel_applet_set_flags(
@@ -277,7 +283,11 @@ static gboolean xmonad_log_applet_factory(
 
     if(retval == FALSE) {
         printf("Wrong applet!\n");
+        #ifdef PANEL_GNOME_IN_PROC
+        return FALSE;
+        #else
         exit(-1);
+        #endif
     }
 
     return retval;
@@ -294,7 +304,11 @@ static gboolean xmonad_log_applet_factory(
 
     if(retval == FALSE) {
         printf("Wrong applet!\n");
+        #ifdef PANEL_GNOME_IN_PROC
+        return NULL;
+        #else
         exit(-1);
+        #endif
     }
 
     return retval;
@@ -310,7 +324,11 @@ static void xmonad_log_applet_construct(XfcePanelPlugin *plugin)
 #endif
 
 #ifdef PANEL_GNOME
+#ifdef PANEL_GNOME_IN_PROC
+PANEL_APPLET_IN_PROCESS_FACTORY(
+#else
 PANEL_APPLET_OUT_PROCESS_FACTORY(
+#endif
     "XmonadLogAppletFactory",
     PANEL_TYPE_APPLET,
 #ifdef PANEL_GNOME2

--- a/org.gnome.panel.XmonadLogApplet.panel-applet.in
+++ b/org.gnome.panel.XmonadLogApplet.panel-applet.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=XmonadLogAppletFactory
-Location=@PLUGIN_DIR@/xmonad-log-applet
+@IN_PROC@
+Location=@PLUGIN_DIR@/@PLUGIN_FILE@
 Name=Xmonad Log Factory
 Description=Factory for the xmonad-log-applet
 


### PR DESCRIPTION
I haven't fully tested this as I was not able to run your fork correctly. It compiles and was running without errors but I did not see anything printed by the applet.

In-process applet is needed for libpanel-applet >= 3.22. The
out-of-process applets are no long supported:

https://github.com/GNOME/gnome-panel/commit/672eb2a8ddaf9a4665320364caa021e3d2e6f463

This conditionally compiles the code based on libpanel-applet version.
Also removes some parts of the code that are no longer supported (i.e.
`panel_applet_set_background_widget()`)